### PR TITLE
(Refactor) unit tests && refactoring

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "submodules/poa-test-setup"]
+	path = submodules/poa-test-setup
+	url = https://github.com/poanetwork/poa-test-setup
+	branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "8"
+
+before_install:
+  - wget https://parity-downloads-mirror.parity.io/v1.9.2/x86_64-unknown-linux-gnu/parity_1.9.2_amd64.deb
+  - sudo dpkg -i parity_1.9.2_amd64.deb
+
+install:
+  - npm install
+
+after-script:
+  - npm run stop-setup

--- a/generateInitialKey/generateInitialKey.js
+++ b/generateInitialKey/generateInitialKey.js
@@ -1,133 +1,61 @@
-let fs = require('fs');
-let keythereum = require("keythereum");
-let Web3 = require('web3');
-let generatePassword = require('password-generator');
-const outputFolder = "./output/";
+const generatePassword = require('password-generator');
 
-generateAddress(generateAddressCallback);
+const constants = require('./utils/constants');
+const addInitialKey = require('./utils/addInitialKey');
+const configureWeb3 = require('./utils/configureWeb3');
+const errorFinish = require('./utils/errorResponse');
+const generateAddress = require('./utils/generateAddress');
+const getConfig = require('./utils/getConfig');
+const getMoC = require('./utils/getMoC');
+const saveToFile = require('./utils/saveToFile');
+const sendEtherToInitialKeyTX = require('./utils/sendEtherToInitialKeyTX');
 
-//generates initial key keystore file
-function generateAddress(cb) {
-	let params = { keyBytes: 32, ivBytes: 16 };
+let rpc
+let config
+let web3
+let MoC
 
-  	let dk = keythereum.create(params);
+async function generateInitialKey(_testKeysManagerAddress) {
+	try { config = await getConfig() }
+	catch (err) { return errorFinish(err); }
 
-  	keythereum.create(params, function (dk) {
-	    let options = {};
-	    let password = generatePassword(20, false);
-	    keythereum.dump(password, dk.privateKey, dk.salt, dk.iv, options, function (keyObject) {
-	    	cb(keyObject, password);
-	    });
-  	});
-}
+	rpc = process.env.RPC || config.Ethereum[config.environment].rpc || 'http://127.0.0.1:8545'
+	let KeysManagerAbi = config.Ethereum.contracts.KeysManager.abi;
+	let KeysManagerAddress = _testKeysManagerAddress ? _testKeysManagerAddress : config.Ethereum.contracts.KeysManager.addr;
 
-//saves initial key keystore file to ./output folder
-function generateAddressCallback(keyObject, password) {
-	let initialKey = `0x${keyObject.address}`;
-	let keyStoreFileName = outputFolder + keyObject.address + ".json";
-	let passwordFileName = outputFolder + keyObject.address + ".key";
-	let content = JSON.stringify(keyObject);
-	fs.writeFileSync(keyStoreFileName, content);
+	try { web3 = await configureWeb3(rpc) }
+	catch (err) { return errorFinish(err); }
+
+	try { MoC = await getMoC(web3) }
+	catch (err) { return errorFinish(err); }
+
+	let keysManager
+	try { keysManager = await new web3.eth.Contract(KeysManagerAbi, KeysManagerAddress) }
+	catch (err) { return errorFinish(err); }
+
+	const password = generatePassword(20, false)
+	const keyObject = await generateAddress(password)
+
+	const initialKey = `0x${keyObject.address}`;
+	const keyStoreFileName = constants.outputFolderPath + keyObject.address + ".json";
+	const passwordFileName = constants.outputFolderPath + keyObject.address + ".key";
+	const content = JSON.stringify(keyObject);
+
+	try { await saveToFile(keyStoreFileName, content) }
+	catch (err) { return errorFinish(err); }
 	console.log(`Initial key ${initialKey} is generated to ${keyStoreFileName}`);
-	fs.writeFileSync(passwordFileName, password);
+
+	try { await saveToFile(passwordFileName, password) }
+	catch (err) { return errorFinish(err); }
 	console.log(`Initial key password is generated to ${passwordFileName}`);
-	attachToContract(initialKey, addInitialKey);
+
+	try { await addInitialKey(keysManager, initialKey, MoC) }
+	catch (err) { return errorFinish(err); }
+
+	try { await sendEtherToInitialKeyTX(web3, initialKey, MoC) }
+	catch (err) { return errorFinish(err); }
+
+	return true;
 }
 
-//attaches to KeysManager contract
-async function attachToContract(initialKey, cb) {
-	let config = getConfig();
-	let web3 = await configureWeb3(config);
-	let contractABI = config.Ethereum.contracts.KeysManager.abi;
-	let contractAddress = config.Ethereum.contracts.KeysManager.addr;
-	let contractInstance = new web3.eth.Contract(contractABI, contractAddress);
-	
-	cb(contractInstance, web3, initialKey);
-}
-
-//gets config from ./config.json
-function getConfig() {
-	let config = JSON.parse(fs.readFileSync('../config.json', 'utf8'));
-	return config;
-}
-
-//configures web3
-async function configureWeb3(config) {
-	let web3;
-	if (typeof web3 !== 'undefined') web3 = new Web3(web3.currentProvider);
-	else web3 = new Web3(new Web3.providers.HttpProvider(config.Ethereum[config.environment].rpc));
-
-	if (!web3) return finishScript(err);
-	
-	let isListening = await web3.eth.net.isListening()
-	if (!isListening) {
-		let err = {code: 500, title: "Error", message: "check RPC"};
-		return finishScript(err);
-	}
-
-	let accounts = await web3.eth.getAccounts()
-	web3.eth.defaultAccount = accounts[0]
-
-	return web3;
-}
-
-
-//activates initial key in KeysManager contract
-async function addInitialKey(contract, web3, initialKey) {
-	let optsEstimate = {from: web3.eth.defaultAccount};
-	let estimatedGas;
-	try {
-		estimatedGas = await contract.methods.initiateKeys(initialKey).estimateGas(optsEstimate);
-	} catch(e) {
-		finishScript(e);
-	}
-	if (!estimatedGas) return;
-	
-	console.log(`Estimated gas to add initial key: {estimatedGas}`)
-
-	addInitialKeyTX(web3, contract, initialKey, estimatedGas)
-	.on("transactionHash", (txHash) => {
-		console.log(`Wait tx ${txHash} to add initial key to be mined...`);
-	})
-	.on("receipt", (receipt) => {
-		console.log(`Tx ${receipt.transactionHash} to add initial key is mined...`);
-		sendEtherToInitialKeyTX(web3, initialKey)
-		.on("transactionHash", (txHash) => {
-			console.log(`Wait tx ${txHash} to send Eth to initial key to be mined...`);
-		})
-		.on("receipt", (receipt) => {
-			console.log("0.1 Eth sent to initial key");
-		})
-		.on("error", (err) => {
-			finishScript(err);
-		});
-	})
-	.on("error", (err) => {
-		finishScript(err);
-	});
-}
-
-//sends tx to activate initial key
-function addInitialKeyTX(web3, contract, initialKey, estimatedGas) {
-    let opts = {from: web3.eth.defaultAccount, gasLimit: estimatedGas}
-    return contract.methods.initiateKeys(initialKey).send(opts);
-}
-
-//sends tx to transafer 0.1 eth from master of ceremony to initial key
-function sendEtherToInitialKeyTX(web3, initialKey) {
-	let BN = web3.utils.BN;
-	let ethToSend = web3.utils.toWei(new BN(100), "milliether");
-	console.log(`WEI to send to initial key: ${ethToSend}`)
-
-	let opts = {from: web3.eth.defaultAccount, to: initialKey, value: ethToSend};
-	return web3.eth.sendTransaction(opts);
-}
-
-//finalizes script, if error arised
-function finishScript(err) {
-	if (err) {
-		console.log("Something went wrong with generating initial key");
-		console.log(err.message);
-		return;
-	}
-}
+module.exports = generateInitialKey

--- a/generateInitialKey/index.js
+++ b/generateInitialKey/index.js
@@ -1,0 +1,4 @@
+const generateInitialKey = require('./generateInitialKey');
+
+generateInitialKey();
+

--- a/generateInitialKey/package-lock.json
+++ b/generateInitialKey/package-lock.json
@@ -1,5 +1,6 @@
 {
-  "version": "1.0.0",
+  "name": "poa-script-moc-generate-initial-key",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7,7 +8,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "dev": true,
       "requires": {
         "mime-types": "2.1.17",
         "negotiator": "0.6.1"
@@ -17,7 +17,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
       "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
-      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -28,26 +27,22 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-      "dev": true
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true,
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.3"
@@ -56,62 +51,62 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-      "dev": true
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
-      "dev": true
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -120,14 +115,12 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "dev": true
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bip66": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -136,7 +129,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.3"
       }
@@ -145,7 +137,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3"
       }
@@ -153,20 +144,17 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
@@ -184,7 +172,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
       "requires": {
         "hoek": "4.2.0"
       }
@@ -193,7 +180,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -202,14 +188,18 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "browserify-aes": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
-      "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
         "cipher-base": "1.0.4",
@@ -219,20 +209,61 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "browserify-cipher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "requires": {
+        "browserify-aes": "1.1.1",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.3"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
+      }
+    },
     "browserify-sha3": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
-      "dev": true,
       "requires": {
         "js-sha3": "0.3.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
       }
     },
     "buffer": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
       "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
-      "dev": true,
       "requires": {
         "base64-js": "1.2.1",
         "ieee754": "1.1.8"
@@ -241,14 +272,12 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-to-arraybuffer": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.2.tgz",
       "integrity": "sha1-0NgFZNwxhmoZdlFUh7OrYg23yEk=",
-      "dev": true,
       "requires": {
         "tape": "3.6.1"
       }
@@ -256,14 +285,12 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "camelcase": {
       "version": "4.1.0",
@@ -273,20 +300,17 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -295,20 +319,17 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -317,7 +338,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-      "dev": true,
       "requires": {
         "graceful-readlink": "1.0.1"
       }
@@ -325,60 +345,60 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
       "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-      "dev": true,
       "requires": {
         "object-assign": "4.1.1",
         "vary": "1.1.2"
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
@@ -390,7 +410,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
@@ -404,7 +423,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
       "requires": {
         "boom": "5.2.0"
       },
@@ -413,18 +431,34 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
           "requires": {
             "hoek": "4.2.0"
           }
         }
       }
     },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "requires": {
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.14",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.3"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -433,7 +467,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -442,7 +475,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
-      "dev": true,
       "requires": {
         "decompress-tar": "4.1.1",
         "decompress-tarbz2": "4.1.1",
@@ -458,7 +490,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "dev": true,
       "requires": {
         "mimic-response": "1.0.0"
       }
@@ -467,7 +498,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-      "dev": true,
       "requires": {
         "file-type": "5.2.0",
         "is-stream": "1.1.0",
@@ -478,7 +508,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-      "dev": true,
       "requires": {
         "decompress-tar": "4.1.1",
         "file-type": "6.2.0",
@@ -490,8 +519,7 @@
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-          "dev": true
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
         }
       }
     },
@@ -499,7 +527,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-      "dev": true,
       "requires": {
         "decompress-tar": "4.1.1",
         "file-type": "5.2.0",
@@ -510,7 +537,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-      "dev": true,
       "requires": {
         "file-type": "3.9.0",
         "get-stream": "2.3.1",
@@ -521,14 +547,12 @@
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true,
           "requires": {
             "object-assign": "4.1.1",
             "pinkie-promise": "2.0.1"
@@ -539,56 +563,72 @@
     "deep-equal": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
-      "dev": true
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
     },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "defined": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
-      "dev": true
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
     },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-      "dev": true
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
+      }
     },
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "dev": true,
       "requires": {
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
@@ -598,14 +638,12 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -614,14 +652,12 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
@@ -635,14 +671,12 @@
     "encodeurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
-      "dev": true
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -650,20 +684,23 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eth-lib": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
       "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.8",
         "elliptic": "6.4.0",
@@ -674,11 +711,41 @@
         "xhr-request-promise": "0.1.2"
       }
     },
+    "ethereum-common": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+      "dev": true
+    },
+    "ethereumjs-tx": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
+      "integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
+      "dev": true,
+      "requires": {
+        "ethereum-common": "0.0.18",
+        "ethereumjs-util": "5.1.4"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.4.tgz",
+      "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "create-hash": "1.1.3",
+        "ethjs-util": "0.1.4",
+        "keccak": "1.2.0",
+        "rlp": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "secp256k1": "3.2.5"
+      }
+    },
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
       "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
@@ -687,22 +754,29 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.4.tgz",
+      "integrity": "sha1-HItoeSV0RO9NPz+7rC3tEs2ZfZM=",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
       }
     },
     "eventemitter3": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-      "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
-      "dev": true
+      "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
       "requires": {
         "md5.js": "1.3.4",
         "safe-buffer": "5.1.1"
@@ -711,14 +785,12 @@
     "expand-template": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
-      "dev": true
+      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
     },
     "express": {
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
-      "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
@@ -755,46 +827,39 @@
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
       }
     },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
       "requires": {
         "pend": "1.2.0"
       }
@@ -802,14 +867,12 @@
     "file-type": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-      "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-      "dev": true
+      "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
     },
     "finalhandler": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "1.0.1",
@@ -823,8 +886,7 @@
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
       }
     },
@@ -832,7 +894,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true,
       "requires": {
         "is-function": "1.0.1"
       }
@@ -840,14 +901,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -857,20 +916,17 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "2.4.0"
@@ -880,7 +936,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
       "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0",
         "fs-extra": "2.1.2",
@@ -891,14 +946,12 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "inherits": "2.0.3",
@@ -910,7 +963,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
       "requires": {
         "aproba": "1.2.0",
         "console-control-strings": "1.1.0",
@@ -925,14 +977,12 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -940,14 +990,12 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "dev": true
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "minimatch": "0.3.0"
@@ -957,7 +1005,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
       "requires": {
         "min-document": "2.19.0",
         "process": "0.5.2"
@@ -967,7 +1014,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
       "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-      "dev": true,
       "requires": {
         "decompress-response": "3.3.0",
         "duplexer3": "0.1.4",
@@ -988,42 +1034,48 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
       "requires": {
         "ajv": "5.5.1",
         "har-schema": "2.0.0"
       }
     },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
     "has-symbol-support-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
-      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
-      "dev": true
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "dev": true,
       "requires": {
         "has-symbol-support-x": "1.4.1"
       }
@@ -1031,14 +1083,12 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hash-base": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3"
       }
@@ -1047,7 +1097,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
@@ -1057,7 +1106,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -1065,11 +1113,16 @@
         "sntp": "2.1.0"
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "1.1.3",
         "minimalistic-assert": "1.0.0",
@@ -1079,14 +1132,12 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-      "dev": true
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
       "requires": {
         "depd": "1.1.1",
         "inherits": "2.0.3",
@@ -1097,14 +1148,12 @@
     "http-https": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-      "dev": true
+      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
     },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -1114,20 +1163,17 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-      "dev": true
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -1136,26 +1182,22 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "ipaddr.js": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
-      "dev": true
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -1163,68 +1205,57 @@
     "is-function": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
-      "dev": true
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-      "dev": true
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-      "dev": true
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "isurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-      "dev": true,
       "requires": {
         "has-to-string-tag-x": "1.4.1",
         "is-object": "1.0.1"
@@ -1233,39 +1264,33 @@
     "js-sha3": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
-      "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=",
-      "dev": true
+      "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
     },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -1274,7 +1299,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -1286,7 +1310,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.2.0.tgz",
       "integrity": "sha1-tTYY/HlhtkL25z8VRu7DMp9+/+A=",
-      "dev": true,
       "requires": {
         "bindings": "1.3.0",
         "inherits": "2.0.3",
@@ -1298,17 +1321,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
       "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
-      "dev": true,
       "requires": {
         "browserify-sha3": "0.0.1",
         "sha3": "1.2.0"
       }
     },
     "keythereum": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/keythereum/-/keythereum-0.5.2.tgz",
-      "integrity": "sha1-c6FfAjLvwsmPJYSSFXotaE6tUgU=",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keythereum/-/keythereum-1.0.2.tgz",
+      "integrity": "sha1-YSukHN4lSxfddzfnUjeubuUWKZI=",
       "requires": {
         "keccak": "1.2.0",
         "secp256k1": "3.2.5",
@@ -1319,20 +1340,17 @@
     "lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-      "dev": true
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
     },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "make-dir": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-      "dev": true,
       "requires": {
         "pify": "3.0.0"
       },
@@ -1340,8 +1358,7 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -1349,7 +1366,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-      "dev": true,
       "requires": {
         "hash-base": "3.0.4",
         "inherits": "2.0.3"
@@ -1359,7 +1375,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-          "dev": true,
           "requires": {
             "inherits": "2.0.3",
             "safe-buffer": "5.1.1"
@@ -1370,38 +1385,41 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
+      }
     },
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "dev": true
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -1409,14 +1427,12 @@
     "mimic-response": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
-      "dev": true
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
     },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
       "requires": {
         "dom-walk": "0.1.1"
       }
@@ -1424,20 +1440,17 @@
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
-      "dev": true
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
       "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-      "dev": true,
       "requires": {
         "lru-cache": "2.7.3",
         "sigmund": "1.0.1"
@@ -1446,14 +1459,12 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -1461,8 +1472,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -1470,34 +1480,87 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
       "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
-      "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
+      }
+    },
+    "mocha": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "mock-fs": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.4.2.tgz",
-      "integrity": "sha512-dF+yxZSojSiI8AXGoxj5qdFWpucndc54Ug+TwlpHFaV7j22MGG+OML2+FVa6xAZtjb/OFFQhOC37Jegx2GbEwA==",
-      "dev": true
+      "integrity": "sha512-dF+yxZSojSiI8AXGoxj5qdFWpucndc54Ug+TwlpHFaV7j22MGG+OML2+FVa6xAZtjb/OFFQhOC37Jegx2GbEwA=="
     },
     "mout": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
-      "dev": true
+      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0",
         "object-assign": "4.1.1",
@@ -1507,41 +1570,55 @@
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "dev": true
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-      "dev": true
+      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "node-abi": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
       "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
-      "dev": true,
       "requires": {
         "semver": "5.4.1"
+      }
+    },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "dev": true
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
         "console-control-strings": "1.1.0",
@@ -1552,14 +1629,12 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "number-to-bn": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
@@ -1568,34 +1643,29 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=",
-      "dev": true
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
     },
     "oboe": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
       "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
-      "dev": true,
       "requires": {
         "http-https": "1.0.0"
       }
@@ -1604,7 +1674,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -1613,7 +1682,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -1621,35 +1689,42 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-      "dev": true
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-timeout": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-      "dev": true,
       "requires": {
         "p-finally": "1.0.0"
+      }
+    },
+    "parse-asn1": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "requires": {
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.1.1",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
       }
     },
     "parse-headers": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
-      "dev": true,
       "requires": {
         "for-each": "0.3.2",
         "trim": "0.0.1"
@@ -1658,8 +1733,7 @@
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-      "dev": true
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "password-generator": {
       "version": "2.2.0",
@@ -1669,23 +1743,38 @@
         "yargs-parser": "8.0.0"
       }
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "requires": {
+        "process": "0.11.10",
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+          "dev": true
+        }
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
-      "dev": true,
       "requires": {
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
@@ -1697,32 +1786,27 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -1731,7 +1815,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.4.1.tgz",
       "integrity": "sha512-99TyEFYTTkBWANT+mwSptmLb9ZCLQ6qKIUE36fXSIOtShB0JNprL2hzBD8F1yIuT9btjFrFEwbRHXhqDi1HmRA==",
-      "dev": true,
       "requires": {
         "expand-template": "1.1.0",
         "github-from-package": "0.0.0",
@@ -1752,36 +1835,43 @@
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "process": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-      "dev": true
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "proxy-addr": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
-      "dev": true,
       "requires": {
         "forwarded": "0.1.2",
         "ipaddr.js": "1.5.2"
+      }
+    },
+    "public-encrypt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.6"
       }
     },
     "pump": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-      "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
         "once": "1.4.0"
@@ -1790,41 +1880,52 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "query-string": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
       "integrity": "sha1-fbBmZCCAS6qSrp8miWKFWnYUPfs=",
-      "dev": true,
       "requires": {
         "strict-uri-encode": "1.1.0"
+      }
+    },
+    "randombytes": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "requires": {
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "randomhex": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
-      "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-      "dev": true
+      "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
     },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-      "dev": true
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -1836,7 +1937,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-      "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -1848,7 +1948,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -1863,7 +1962,6 @@
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -1892,8 +1990,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
@@ -1901,7 +1998,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true,
       "requires": {
         "through": "2.3.8"
       }
@@ -1910,7 +2006,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       },
@@ -1919,7 +2014,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -1933,7 +2027,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
           }
@@ -1944,23 +2037,26 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true,
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
       }
     },
+    "rlp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
+      "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A=",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "scrypt": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
       "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "dev": true,
       "requires": {
         "nan": "2.8.0"
       }
@@ -1969,7 +2065,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
-      "dev": true,
       "requires": {
         "scrypt": "6.0.3",
         "scryptsy": "1.2.1"
@@ -1979,7 +2074,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
       "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
-      "dev": true,
       "requires": {
         "pbkdf2": "3.0.14"
       }
@@ -1988,7 +2082,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.2.5.tgz",
       "integrity": "sha1-Dd5bJ+UCFmX23/ynssPgEMbBPJM=",
-      "dev": true,
       "requires": {
         "bindings": "1.3.0",
         "bip66": "1.1.5",
@@ -2004,7 +2097,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
-      "dev": true,
       "requires": {
         "commander": "2.8.1"
       }
@@ -2012,14 +2104,12 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.1",
@@ -2039,8 +2129,7 @@
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
       }
     },
@@ -2048,7 +2137,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-      "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -2060,7 +2148,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
       "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
-      "dev": true,
       "requires": {
         "body-parser": "1.18.2",
         "cors": "2.8.4",
@@ -2072,26 +2159,22 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-      "dev": true
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sha.js": {
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -2101,7 +2184,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
       "integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
-      "dev": true,
       "requires": {
         "nan": "2.8.0"
       }
@@ -2109,20 +2191,17 @@
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-get": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
       "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "unzip-response": "1.0.2",
@@ -2132,14 +2211,12 @@
     "sjcl": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.6.tgz",
-      "integrity": "sha1-ZBVGKmPMDUIVxJuuydP6DBtTUg8=",
-      "dev": true
+      "integrity": "sha1-ZBVGKmPMDUIVxJuuydP6DBtTUg8="
     },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
       "requires": {
         "hoek": "4.2.0"
       }
@@ -2148,7 +2225,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -2163,46 +2239,40 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-      "dev": true
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -2211,7 +2281,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-      "dev": true,
       "requires": {
         "is-natural-number": "4.0.1"
       }
@@ -2220,7 +2289,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }
@@ -2228,14 +2296,21 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
     },
     "swarm-js": {
       "version": "0.1.37",
       "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
       "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
-      "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "buffer": "5.0.8",
@@ -2256,7 +2331,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/tape/-/tape-3.6.1.tgz",
       "integrity": "sha1-SJPdU+KApfWMDOswwsDrs7zVHh8=",
-      "dev": true,
       "requires": {
         "deep-equal": "0.2.2",
         "defined": "0.0.0",
@@ -2271,7 +2345,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
       "requires": {
         "block-stream": "0.0.9",
         "fstream": "1.0.11",
@@ -2282,7 +2355,6 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
       "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-      "dev": true,
       "requires": {
         "chownr": "1.0.1",
         "mkdirp": "0.5.1",
@@ -2294,7 +2366,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
-      "dev": true,
       "requires": {
         "bl": "1.2.1",
         "end-of-stream": "1.4.0",
@@ -2306,7 +2377,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
       "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
-      "dev": true,
       "requires": {
         "bluebird": "2.11.0",
         "commander": "2.8.1",
@@ -2318,8 +2388,7 @@
         "bluebird": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         }
       }
     },
@@ -2327,7 +2396,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0"
       }
@@ -2336,7 +2404,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "dev": true,
       "requires": {
         "thenify": "3.3.0"
       }
@@ -2344,20 +2411,17 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -2365,14 +2429,12 @@
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -2381,14 +2443,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
@@ -2398,7 +2458,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
       "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
-      "dev": true,
       "requires": {
         "is-typedarray": "1.0.0"
       }
@@ -2406,14 +2465,12 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-      "dev": true
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unbzip2-stream": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
-      "dev": true,
       "requires": {
         "buffer": "3.6.0",
         "through": "2.3.8"
@@ -2422,14 +2479,12 @@
         "base64-js": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
-          "dev": true
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
         },
         "buffer": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
-          "dev": true,
           "requires": {
             "base64-js": "0.0.8",
             "ieee754": "1.1.8",
@@ -2441,26 +2496,22 @@
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unzip-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
       "requires": {
         "prepend-http": "1.0.4"
       }
@@ -2468,50 +2519,59 @@
     "url-set-query": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-      "dev": true
+      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
     },
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-      "dev": true
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "utf8": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-      "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
-      "dev": true
+      "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-      "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg=",
-      "dev": true
+      "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
     },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -2519,323 +2579,291 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
-      "integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
-      "dev": true,
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.30.tgz",
+      "integrity": "sha1-rT52GEWusvQKd2DN51eTdzpDHs0=",
       "requires": {
-        "web3-bzz": "1.0.0-beta.26",
-        "web3-core": "1.0.0-beta.26",
-        "web3-eth": "1.0.0-beta.26",
-        "web3-eth-personal": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26",
-        "web3-shh": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-bzz": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.26.tgz",
-      "integrity": "sha1-WFihjN5XaHSAGoPR30IJX8lYWQw=",
-      "dev": true,
-      "requires": {
-        "got": "7.1.0",
-        "swarm-js": "0.1.37",
-        "underscore": "1.8.3"
-      }
-    },
-    "web3-core": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.26.tgz",
-      "integrity": "sha1-hczKK2KfmK3+sOK21+K31nepeVk=",
-      "dev": true,
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-requestmanager": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-helpers": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.26.tgz",
-      "integrity": "sha1-2G31xrMQ/FjFtv9Woz0mePu8PcM=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-method": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.26.tgz",
-      "integrity": "sha1-SdhpoacvMiNXbIkmCe7kDTsiVXw=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-promievent": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.26.tgz",
-      "integrity": "sha1-BkJSUZ35t+banCD1lKAuz+nDU8E=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.3.1",
-        "eventemitter3": "1.1.1"
+        "web3-bzz": "1.0.0-beta.30",
+        "web3-core": "1.0.0-beta.30",
+        "web3-eth": "1.0.0-beta.30",
+        "web3-eth-personal": "1.0.0-beta.30",
+        "web3-net": "1.0.0-beta.30",
+        "web3-shh": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
       },
       "dependencies": {
         "bluebird": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0=",
-          "dev": true
-        }
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.26.tgz",
-      "integrity": "sha1-dffvfy/GpLDTRr8AVCFXuB4UsDM=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-providers-http": "1.0.0-beta.26",
-        "web3-providers-ipc": "1.0.0-beta.26",
-        "web3-providers-ws": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-subscriptions": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.26.tgz",
-      "integrity": "sha1-0W0dbr3GDXCL9aR7hxZt1+jBl6A=",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "1.1.1",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26"
-      }
-    },
-    "web3-eth": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.26.tgz",
-      "integrity": "sha1-aMAkw1a4ZWrDaVyPk9e2GzgQRKU=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-eth-abi": "1.0.0-beta.26",
-        "web3-eth-accounts": "1.0.0-beta.26",
-        "web3-eth-contract": "1.0.0-beta.26",
-        "web3-eth-iban": "1.0.0-beta.26",
-        "web3-eth-personal": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.26.tgz",
-      "integrity": "sha1-Ku3ASDxna1kcccBBJXIZj3omb+I=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.26.tgz",
-      "integrity": "sha1-N/18d3BCBGX95ZGCKYkad3OAehM=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.3.1",
-        "eth-lib": "0.2.5",
-        "scrypt.js": "0.2.0",
-        "underscore": "1.8.3",
-        "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0=",
-          "dev": true
-        },
-        "eth-lib": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.5.tgz",
-          "integrity": "sha512-pXs4ryU+7S8MPpkQpNqG4JlXEec87kbXowQbYzRVV+c5XUccrO6WOxVPDicxql1AXSBzfmBSFVkvvG+H4htuxg==",
-          "dev": true,
-          "requires": {
-            "bn.js": "4.11.8",
-            "elliptic": "6.4.0",
-            "xhr-request-promise": "0.1.2"
-          }
+          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.30.tgz",
+          "integrity": "sha1-JDTaGDwjmqqlwBP2IwdCnqkd1wY=",
+          "requires": {
+            "got": "7.1.0",
+            "swarm-js": "0.1.37",
+            "underscore": "1.8.3"
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.30.tgz",
+          "integrity": "sha1-919NO4W+dMdnRjeSHD4BO8XSdnk=",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-requestmanager": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.30.tgz",
+          "integrity": "sha1-oADO4/CgnuoT10tXMDNdRjX+Hy8=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-eth-iban": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.30.tgz",
+          "integrity": "sha1-jdb/eJ6NFWO4eG0Tp4x/rO+uRxw=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-promievent": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.30.tgz",
+          "integrity": "sha1-YgUZK/sJdEETIialk57FrtOoopE=",
+          "requires": {
+            "bluebird": "3.3.1",
+            "eventemitter3": "1.1.1"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.30.tgz",
+          "integrity": "sha1-buVvuKbLhf0BswgIVPUNZOUiQMY=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-providers-http": "1.0.0-beta.30",
+            "web3-providers-ipc": "1.0.0-beta.30",
+            "web3-providers-ws": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.30.tgz",
+          "integrity": "sha1-MWUsdTVsP2floZzRS40xS61OISc=",
+          "requires": {
+            "eventemitter3": "1.1.1",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.30.tgz",
+          "integrity": "sha1-ApsV4Uy2CLnP4CYDtQTWUYcPBQE=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-eth-abi": "1.0.0-beta.30",
+            "web3-eth-accounts": "1.0.0-beta.30",
+            "web3-eth-contract": "1.0.0-beta.30",
+            "web3-eth-iban": "1.0.0-beta.30",
+            "web3-eth-personal": "1.0.0-beta.30",
+            "web3-net": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.30.tgz",
+          "integrity": "sha1-bqUsmZqFBbR8L4i6YdKmgKEGZAk=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.30.tgz",
+          "integrity": "sha1-jwobNCxCg4EjciQqbi3yaIh7O3A=",
+          "requires": {
+            "bluebird": "3.3.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "0.2.0",
+            "underscore": "1.8.3",
+            "uuid": "2.0.1",
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0",
+                "xhr-request-promise": "0.1.2"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.30.tgz",
+          "integrity": "sha1-1+uiOFCE3/PHWqxII1ryyNLWolg=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-promievent": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-eth-abi": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.30.tgz",
+          "integrity": "sha1-OwgKXE2h+jdHexfkyQB4G5IVBkU=",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.30.tgz",
+          "integrity": "sha1-i9TvQLO1+EHdOouXhz2dx5HK90g=",
+          "requires": {
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-net": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.30.tgz",
+          "integrity": "sha1-CjUu3ilubUt/iLZ6pHTklwPec78=",
+          "requires": {
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.30.tgz",
+          "integrity": "sha1-zajZEzxvMdGoEtxaQq8Ay+qYzYY=",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.30",
+            "xhr2": "0.1.4"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.30.tgz",
+          "integrity": "sha1-7i2NGKPxILd3BEpW5n4K7iCFRYc=",
+          "requires": {
+            "oboe": "2.1.3",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.30.tgz",
+          "integrity": "sha1-muaanq2Kh2H4Y3n6NHttta5EsS0=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.30.tgz",
+          "integrity": "sha1-K/4yINlY/0ylkgF3kIUrxXt7DKc=",
+          "requires": {
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-net": "1.0.0-beta.30"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.30.tgz",
+          "integrity": "sha1-6uQIzI1tb+zI1Ql8/q1Rdz8jH/k=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+          "requires": {
+            "debug": "2.6.9",
+            "nan": "2.8.0",
+            "typedarray-to-buffer": "3.1.2",
+            "yaeti": "0.0.6"
+          }
         }
-      }
-    },
-    "web3-eth-contract": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.26.tgz",
-      "integrity": "sha1-fny3FXqrYMUi20353p3L2G2BOwk=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-promievent": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-eth-abi": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.26.tgz",
-      "integrity": "sha1-6MI2GOpapmJ73pHHPqi18ZGe43Q=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-eth-personal": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.26.tgz",
-      "integrity": "sha1-K4gDs01HJEfPW76BziVQSxMb7QY=",
-      "dev": true,
-      "requires": {
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-net": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.26.tgz",
-      "integrity": "sha1-UY0oO1AANf7kgL9ocIljRyWrZLM=",
-      "dev": true,
-      "requires": {
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.26.tgz",
-      "integrity": "sha1-GwFUu3UY027TT5EKZl5FFSoKyKE=",
-      "dev": true,
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.26",
-        "xhr2": "0.1.4"
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.26.tgz",
-      "integrity": "sha1-HffepV5nE1yQRaJsUzso0bbJ2mQ=",
-      "dev": true,
-      "requires": {
-        "oboe": "2.1.3",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26"
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.26.tgz",
-      "integrity": "sha1-z0ylFUpPsVok1GgtEJUO4Emku2E=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
-      }
-    },
-    "web3-shh": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.26.tgz",
-      "integrity": "sha1-YMrff1V71rRRVHXd4z4uV7gKgg4=",
-      "dev": true,
-      "requires": {
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26"
-      }
-    },
-    "web3-utils": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.26.tgz",
-      "integrity": "sha1-8ErYwUSxeBxrIMKBjgUyy55tyhU=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "eth-lib": "0.1.27",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randomhex": "0.1.5",
-        "underscore": "1.8.3",
-        "utf8": "2.1.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
-      }
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "nan": "2.8.0",
-        "typedarray-to-buffer": "3.1.2",
-        "yaeti": "0.0.6"
       }
     },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2"
       }
@@ -2843,14 +2871,12 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
       "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
-      "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
@@ -2861,7 +2887,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
       "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
-      "dev": true,
       "requires": {
         "global": "4.3.2",
         "is-function": "1.0.1",
@@ -2873,7 +2898,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.0.1.tgz",
       "integrity": "sha1-g/CKSyC+7Geowcco6BAvTJ7svdo=",
-      "dev": true,
       "requires": {
         "buffer-to-arraybuffer": "0.0.2",
         "object-assign": "3.0.0",
@@ -2887,14 +2911,12 @@
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "timed-out": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
-          "dev": true
+          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
         }
       }
     },
@@ -2902,7 +2924,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
       "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
-      "dev": true,
       "requires": {
         "xhr-request": "1.0.1"
       }
@@ -2910,20 +2931,17 @@
     "xhr2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
-      "dev": true
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-      "dev": true
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yargs-parser": {
       "version": "8.0.0",
@@ -2937,7 +2955,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
-      "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13",
         "fd-slicer": "1.0.1"

--- a/generateInitialKey/package.json
+++ b/generateInitialKey/package.json
@@ -1,24 +1,31 @@
 {
-  "name": "",
-  "version": "1.0.0",
-  "description": "",
-  "devDependencies": {
-    "keythereum": "^0.5.2",
-    "password-generator": "^2.2.0",
-    "web3": "^1.0.0-beta.26"
-  },
+  "name": "poa-script-moc-generate-initial-key",
+  "version": "2.0.0",
+  "description": "generates initial key",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/poanetwork/poa-scripts-moc"
   },
   "keywords": [],
-  "author": "",
+  "author": "POA Network",
   "license": "ISC",
   "bugs": {
     "url": "/issues"
   },
   "homepage": "#README",
   "dependencies": {
-    "password-generator": "^2.1.0"
+    "keythereum": "^1.0.2",
+    "password-generator": "^2.2.0",
+    "web3": "^1.0.0-beta.29"
+  },
+  "devDependencies": {
+    "ethereumjs-tx": "^1.3.3",
+    "mocha": "^5.0.1",
+    "node-dir": "^0.1.17",
+    "path": "^0.12.7"
+  },
+  "scripts": {
+    "start": "node index",
+    "test": "mocha"
   }
 }

--- a/generateInitialKey/test/test.js
+++ b/generateInitialKey/test/test.js
@@ -1,0 +1,173 @@
+const fs = require('fs');
+const dir = require('node-dir');
+const path = require('path');
+const keythereum = require("keythereum");
+const EthereumTx = require('ethereumjs-tx');
+const assert = require('assert');
+const generateInitialKey = require('../generateInitialKey');
+const configureWeb3 = require('../utils/configureWeb3');
+const getConfig = require('../utils/getConfig');
+const constants = require('../utils/constants');
+
+const keyExt = ".key";
+const jsonExt = ".json";
+const listOfExt = [keyExt, jsonExt];
+
+let web3;
+let rpc;
+
+let keyStorePath;
+let passwordPath;
+let keyStore;
+let password;
+let initialKey;
+let KeysManagerAddress;
+
+describe("Initial key generation", async function() {
+
+	it('should return KeysManager contract address', async function() {
+		let contracts;
+		try { contracts = await readFile("../submodules/poa-test-setup/submodules/poa-network-consensus-contracts/contracts.json") }
+		catch (err) { return assert.fail(err.message) }
+		contracts = JSON.parse(contracts);
+		KeysManagerAddress = contracts.KEYS_MANAGER_ADDRESS;
+
+		assert.ok(true)
+	})
+
+	it('should successfully generate initial key', async function() {
+		this.timeout(20000);
+		let status
+		try { status = await generateInitialKey(KeysManagerAddress) }
+		catch (err) { return assert.fail(err.message) }
+
+		assert.equal(status, true);
+	})
+
+	it('should get .json and .key in output directory', async function() {
+		try { await getOutput() }
+		catch (err) { return assert.fail(err.message) }
+
+		assert.ok(true)
+	})
+
+	it('initial key should be valid to generate production keys', async function() {
+		this.timeout(10000);
+		initialKey = `0x${keyStore.address}`
+		
+		var privateKey = keythereum.recover(password, keyStore);
+		const privateKeyHex = Buffer.from(privateKey, 'hex')
+
+		try { config = await getConfig() }
+		catch (err) { return errorFinish(err); }
+
+		rpc = process.env.RPC || config.Ethereum[config.environment].rpc || 'http://127.0.0.1:8545'
+
+		try { web3 = await configureWeb3(rpc) }
+		catch (err) { return errorFinish(err); }
+
+		let methodSignature = web3.eth.abi.encodeFunctionSignature('createKeys(address,address,address)')
+		
+		let miningKey = '0xb8487eed31cf5c559bf3f4edd166b949553d0d11'
+		let payoutKey = '0x1b3cb81e51011b549d78bf720b0d924ac763a7c2'
+		let votingKey = '0xfca70e67b3f93f679992cd36323eeb5a5370c8e4'
+		let params = web3.eth.abi.encodeParameters(["address", "address", "address"], [miningKey, payoutKey, votingKey]);
+		let txData = methodSignature + params.substr(2)
+		
+		var nonce = await web3.eth.getTransactionCount(initialKey);
+		var nonceHex = web3.utils.toHex(nonce);
+		const rawTx = {
+		  nonce: nonceHex,
+		  gasPrice: 21000,
+		  gasLimit: 400000,
+		  to: KeysManagerAddress, 
+		  value: 0,
+		  data: txData,
+		  chainId: web3.utils.toHex(web3.version.network)
+		};
+		
+		var tx = new EthereumTx(rawTx);
+		tx.sign(privateKeyHex);
+
+		var serializedTx = tx.serialize();
+
+		let receipt;
+		try { receipt = await web3.eth.sendSignedTransaction("0x" + serializedTx.toString('hex')) }
+		catch (err) { return returnError(err.message); }
+		
+		if (receipt.status == "0x0")
+			return returnError("Transaction failed");
+
+		fs.unlinkSync(keyStorePath)
+		fs.unlinkSync(passwordPath)
+
+		assert.ok(true)
+	})
+})
+
+function getOutput() {
+	return new Promise((resolve, reject) => {
+		dir.files(constants.outputFolderPath, async function(err, files) {
+		    if (err) reject(err);
+
+		    files = files.filter(e => e !== `${constants.outputFolderName}/.DS_Store` && e !== `${constants.outputFolderName}/.gitkeep`);
+		    
+		    if (files.length != 2) {
+		    	let err = {message: "number of output files != 2"}
+		    	reject(err)
+		    }
+
+		    for (let i in files) {
+		    	let file = files[i]
+		    	let ext = path.extname(file)
+		    	if (!listOfExt.includes(ext)) reject({message: `Incorrect ext ${ext} of file`})
+
+		    	if (ext == jsonExt) {
+		    		keyStorePath = file
+		    		try { keyStore = await checkKeyStoreFile(file) }
+					catch (err) { return reject(err) }
+		    	} else if (ext = keyExt) {
+		    		passwordPath = file
+		    		try { password = await readFile(file) }
+					catch (err) { return reject(err) }
+		    	}
+		    }
+		    resolve();
+		});
+	});
+}
+
+function checkKeyStoreFile(file) {
+	return new Promise(async (resolve, reject) => {
+		try { content = await readFile(file) }
+		catch (err) { return reject(err) }
+
+		keyStore = JSON.parse(content)
+		resolve(keyStore)
+	});
+}
+
+function readFile(file) {
+	return new Promise((resolve, reject) => {
+		fs.readFile(file, 'utf8', (err, content) => {
+			if (err) reject(err);
+			try {
+			  	resolve(content)
+			} catch (e) {
+			  	reject(e)
+			}
+		});
+	});
+}
+
+function sendRawTX() {
+	web3.eth.sendRawTransaction("0x" + serializedTx.toString('hex'), function(err, hash) {
+			sendRawTransactionResponse(err, hash, response);
+		});
+}
+
+function returnError(err) {
+	fs.unlinkSync(keyStorePath)
+	fs.unlinkSync(passwordPath)
+	assert.fail(err)
+}

--- a/generateInitialKey/test/test.js
+++ b/generateInitialKey/test/test.js
@@ -6,6 +6,7 @@ const EthereumTx = require('ethereumjs-tx');
 const assert = require('assert');
 const generateInitialKey = require('../generateInitialKey');
 const configureWeb3 = require('../utils/configureWeb3');
+const errorFinish = require('../utils/errorResponse');
 const getConfig = require('../utils/getConfig');
 const constants = require('../utils/constants');
 
@@ -58,6 +59,7 @@ describe("Initial key generation", async function() {
 		var privateKey = keythereum.recover(password, keyStore);
 		const privateKeyHex = Buffer.from(privateKey, 'hex')
 
+		let config;
 		try { config = await getConfig() }
 		catch (err) { return errorFinish(err); }
 
@@ -126,7 +128,7 @@ function getOutput() {
 		    		keyStorePath = file
 		    		try { keyStore = await checkKeyStoreFile(file) }
 					catch (err) { return reject(err) }
-		    	} else if (ext = keyExt) {
+		    	} else if (ext == keyExt) {
 		    		passwordPath = file
 		    		try { password = await readFile(file) }
 					catch (err) { return reject(err) }
@@ -139,6 +141,7 @@ function getOutput() {
 
 function checkKeyStoreFile(file) {
 	return new Promise(async (resolve, reject) => {
+		let content;
 		try { content = await readFile(file) }
 		catch (err) { return reject(err) }
 
@@ -158,12 +161,6 @@ function readFile(file) {
 			}
 		});
 	});
-}
-
-function sendRawTX() {
-	web3.eth.sendRawTransaction("0x" + serializedTx.toString('hex'), function(err, hash) {
-			sendRawTransactionResponse(err, hash, response);
-		});
 }
 
 function returnError(err) {

--- a/generateInitialKey/utils/addInitialKey.js
+++ b/generateInitialKey/utils/addInitialKey.js
@@ -1,0 +1,35 @@
+//activates initial key in KeysManager contract
+function addInitialKey(contract, initialKey, MoC) {
+	return new Promise(async (resolve, reject) => {
+		let optsEstimate = {from: MoC};
+		let estimatedGas;
+		try {
+			estimatedGas = await contract.methods.initiateKeys(initialKey).estimateGas(optsEstimate);
+		} catch(e) {
+			reject(e);
+		}
+		if (!estimatedGas) return;
+		
+		console.log(`Estimated gas to add initial key: ${estimatedGas}`)
+
+		addInitialKeyTX(contract, initialKey, estimatedGas, MoC)
+		.on("transactionHash", (txHash) => {
+			console.log(`Wait tx ${txHash} to add initial key to be mined...`);
+		})
+		.on("receipt", (receipt) => {
+			console.log(`Tx ${receipt.transactionHash} to add initial key is mined...`);
+			resolve();
+		})
+		.on("error", (err) => {
+			reject(err);
+		});
+	})
+}
+
+//sends tx to activate initial key
+function addInitialKeyTX(contract, initialKey, estimatedGas, MoC) {
+    let opts = {from: MoC, gasLimit: estimatedGas}
+    return contract.methods.initiateKeys(initialKey).send(opts);
+}
+
+module.exports = addInitialKey

--- a/generateInitialKey/utils/configureWeb3.js
+++ b/generateInitialKey/utils/configureWeb3.js
@@ -3,13 +3,13 @@ const { errorFinish } = require('./errorResponse');
 
 //configures web3
 function configureWeb3(rpc) {
-	let web3;
-	if (typeof web3 !== 'undefined') web3 = new Web3(web3.currentProvider);
-	else web3 = new Web3(new Web3.providers.HttpProvider(rpc));
-
-	if (!web3) return errorFinish(err);
-	
 	return new Promise((resolve, reject) => {
+		let web3;
+		if (typeof web3 !== 'undefined') web3 = new Web3(web3.currentProvider);
+		else web3 = new Web3(new Web3.providers.HttpProvider(rpc));
+
+		if (!web3) return reject({code: 500, title: "error", message: "web3 is undefined"});
+	
 		web3.eth.net.isListening()
 		.then(function(isListening) {
 			if (!isListening) {

--- a/generateInitialKey/utils/configureWeb3.js
+++ b/generateInitialKey/utils/configureWeb3.js
@@ -1,0 +1,27 @@
+const Web3 = require('web3');
+const { errorFinish } = require('./errorResponse');
+
+//configures web3
+function configureWeb3(rpc) {
+	let web3;
+	if (typeof web3 !== 'undefined') web3 = new Web3(web3.currentProvider);
+	else web3 = new Web3(new Web3.providers.HttpProvider(rpc));
+
+	if (!web3) return errorFinish(err);
+	
+	return new Promise((resolve, reject) => {
+		web3.eth.net.isListening()
+		.then(function(isListening) {
+			if (!isListening) {
+				var err = {code: 500, title: "Error", message: "check RPC"};
+				return errorFinish(err);
+			}
+
+			resolve(web3);
+		}).catch((err) => {
+			reject(err);
+		});
+	});
+}
+
+module.exports = configureWeb3

--- a/generateInitialKey/utils/constants.js
+++ b/generateInitialKey/utils/constants.js
@@ -1,0 +1,7 @@
+const outputFolderName = "output";
+const outputFolderPath = `./${outputFolderName}/`;
+
+module.exports = {
+	outputFolderName,
+	outputFolderPath
+}

--- a/generateInitialKey/utils/errorResponse.js
+++ b/generateInitialKey/utils/errorResponse.js
@@ -1,0 +1,9 @@
+//finalizes script, if error arised
+function errorFinish(err) {
+	console.log("Something went wrong with generating initial key");
+	if (err) {
+		console.log(err.message);
+	}
+}
+
+module.exports = errorFinish

--- a/generateInitialKey/utils/generateAddress.js
+++ b/generateInitialKey/utils/generateAddress.js
@@ -5,8 +5,6 @@ function generateAddress(password) {
 	return new Promise((resolve, reject) => {
 		let params = { keyBytes: 32, ivBytes: 16 };
 
-	  	let dk = keythereum.create(params);
-
 	  	keythereum.create(params, function (dk) {
 		    let options = {};
 		    keythereum.dump(password, dk.privateKey, dk.salt, dk.iv, options, function (keyObject) {

--- a/generateInitialKey/utils/generateAddress.js
+++ b/generateInitialKey/utils/generateAddress.js
@@ -1,0 +1,19 @@
+const keythereum = require("keythereum");
+
+//generates initial key keystore file
+function generateAddress(password) {
+	return new Promise((resolve, reject) => {
+		let params = { keyBytes: 32, ivBytes: 16 };
+
+	  	let dk = keythereum.create(params);
+
+	  	keythereum.create(params, function (dk) {
+		    let options = {};
+		    keythereum.dump(password, dk.privateKey, dk.salt, dk.iv, options, function (keyObject) {
+		    	resolve(keyObject);
+		    });
+	  	});
+	})
+}
+
+module.exports = generateAddress

--- a/generateInitialKey/utils/getConfig.js
+++ b/generateInitialKey/utils/getConfig.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+//gets config from ./config.json
+function getConfig() {
+	return new Promise(async (resolve, reject) => {
+		const configPath = '../config.json';
+		fs.access(configPath, fs.F_OK, function(err) {
+		    if (err) {
+		        return reject(err)
+		    } else {
+		    	fs.readFile(configPath, 'utf8', (err, config) => {
+				  if (err) reject(err);
+				  resolve(JSON.parse(config));
+				});
+		    }
+		})
+	});
+}
+
+module.exports = getConfig

--- a/generateInitialKey/utils/getMoC.js
+++ b/generateInitialKey/utils/getMoC.js
@@ -1,0 +1,15 @@
+function getMoC(web3) {
+	return new Promise((resolve, reject) => {
+		web3.eth.getAccounts()
+		.then((accounts) => {
+			if (accounts.length > 0) {
+				resolve(accounts[0])
+			} else {
+				const err = {code: 500, title: "Error", message: "There is no unlocked accounts"}
+				reject(err)
+			}
+		})
+	})
+}
+
+module.exports = getMoC

--- a/generateInitialKey/utils/saveToFile.js
+++ b/generateInitialKey/utils/saveToFile.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+
+function saveToFile(filename, content) {
+	return new Promise((resolve, reject) => {
+		fs.writeFile(filename, content, (err) => {
+		  if (err) reject(err);
+		  resolve();
+		});
+	});
+}
+
+module.exports = saveToFile

--- a/generateInitialKey/utils/sendEtherToInitialKeyTX.js
+++ b/generateInitialKey/utils/sendEtherToInitialKeyTX.js
@@ -1,0 +1,23 @@
+//sends tx to transafer 0.1 eth from master of ceremony to initial key
+function sendEtherToInitialKeyTX(web3, initialKey, MoC) {
+	return new Promise((resolve, reject) => {
+		let BN = web3.utils.BN;
+		let ethToSend = web3.utils.toWei(new BN(100), "milliether");
+		console.log(`WEI to send to initial key: ${ethToSend}`)
+
+		let opts = {from: MoC, to: initialKey, value: ethToSend};
+		web3.eth.sendTransaction(opts)
+		.on("transactionHash", (txHash) => {
+			console.log(`Wait tx ${txHash} to send ETH to initial key to be mined...`);
+		})
+		.on("receipt", (receipt) => {
+			console.log("0.1 ETH successfully sent to initial key");
+			resolve();
+		})
+		.on("error", (err) => {
+			reject(err);
+		});
+	})
+}
+
+module.exports = sendEtherToInitialKeyTX

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "poa-scripts-moc",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "poa-scripts-moc",
+  "version": "1.0.0",
+  "description": "## generateInitialKey",
+  "main": "index.js",
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {
+    "prepare-setup": "cd ./submodules/poa-test-setup/ && npm i && npm run start-moc-setup",
+    "start-unit-test": "cd ./generateInitialKey && npm i && npm test",
+    "stop-setup": "cd ./submodules/poa-test-setup/ && npm run stop-test-setup > /dev/null 2>&1 &",
+    "test": "npm run prepare-setup && npm run start-unit-test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/poanetwork/poa-scripts-moc.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/poanetwork/poa-scripts-moc/issues"
+  },
+  "homepage": "https://github.com/poanetwork/poa-scripts-moc#readme"
+}


### PR DESCRIPTION
unit tests && refactoring for `generateInitalKeys` script for clones of POA Network.
This approach will be implemented also for `poa-scripts-validators` repos and for all DApps of POA Network

- Unit tests are written with Mocha
- POA Network setup is created with https://github.com/poanetwork/poa-test-setup
- unit tests simply start with `npm test` command. POA Network Setup is configured and tests are executed on it.
- .travis.yml is added to this repo. Travis CI can be configured for this repo.
- refactoring affects the handling of errors, that was not handled before
- `node generetaInititalKey` -> `npm start`

The same PR will be created for Sokol branch after merging.