### PR TITLE
Update Web3 version for `generateInitialKey`

### DIFF
--- a/generateInitialKey/package.json
+++ b/generateInitialKey/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "keythereum": "^1.0.2",
     "password-generator": "^2.2.0",
-    "web3": "^1.0.0-beta.29"
+    "web3": "1.0.0-beta.34"
   },
   "devDependencies": {
     "ethereumjs-tx": "^1.3.3",


### PR DESCRIPTION
We need to increase `Web3` version here to make [`poa-test-setup`](https://github.com/poanetwork/poa-test-setup) work with node js v10. For node v10 the step `npm run launch-ceremony-light` doesn't work due to the following error:

![image](https://user-images.githubusercontent.com/33550681/60289305-c84bf300-991e-11e9-9a2e-0926eed32ab1.png)
